### PR TITLE
Fix windows specific issue on the K3 project creation wizard

### DIFF
--- a/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateDSAProjectHandler.java
+++ b/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/commands/CreateDSAProjectHandler.java
@@ -95,7 +95,7 @@ public class CreateDSAProjectHandler extends AbstractDslSelectHandler implements
 		
 		String ecoreURI = null;
 		IFile dslFile = getDslFileFromSelection(event);
-		Resource res = (new ResourceSetImpl()).getResource(URI.createURI(dslFile.getFullPath().toOSString()), true);
+		Resource res = (new ResourceSetImpl()).getResource(URI.createPlatformResourceURI(dslFile.getFullPath().toOSString(), true), true);
 		Dsl dsl = (Dsl) res.getContents().get(0);
 		Optional<Entry> syntax = dsl.getEntries()
 			.stream()


### PR DESCRIPTION
in windows  (the bug doesn't occurs on linux and Mac)

right click on the dsl project, then generate a K3DSA project fails with a "file not found" 

the indicated path in the trace was correct, ponly the creation of the URI failed


This PR fixes this.