### PR TITLE
Metaprogramming approach name changed to FullyQualifiedName

### DIFF
--- a/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.metaprog/plugin.xml
+++ b/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.metaprog/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.gemoc.gemoc_language_workbench.metaprog">
       <approach
-            name="kermeta3"
+            name="org.eclipse.gemoc.metaprog.kermeta3"
             validator="org.eclipse.gemoc.execution.sequential.javaxdsml.ruleprovider.Kermeta3RuleProvider">
       </approach>
    </extension>


### PR DESCRIPTION
Name changed from "kermeta3" to "org.eclipse.gemoc.metaprog.kermeta3".

Signed-off-by: Ronan Guéguen <gueguen.ronan1@gmail.com>