### PR TITLE
Bump eclipse 2020-12

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>1.7.0</version>
+    <version>2.2.0</version>
   </extension>
 </extensions>

--- a/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/plugin.xml
+++ b/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/plugin.xml
@@ -105,7 +105,7 @@
     </wizard>
     <wizard class="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.SequentialExtendedLanguageNewWizard" id="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.projectContent.SequentialExtendedLanguage" name="GEMOC Melange based sequential project (extended languages)" targetPluginId="fr.inria.diverse.melange.ui">
       <description>
-            This template use a language extension mecanism (inheritance) in order to create a sequential language defined using a Melange language that is extended with K3 aspects in order to define a second language.
+            This template use a language extension mechanism (inheritance) in order to create a sequential language defined using a Melange language that is extended with K3 aspects in order to define a second language.
          </description>
     </wizard>
   </extension>

--- a/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/templates/resources.properties
+++ b/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/src/org/eclipse/gemoc/execution/sequential/javaxdsml/ide/ui/templates/resources.properties
@@ -64,6 +64,6 @@ SequentialExtendedLanguageTemplate_ecoreFileLocationTooltip=Ecore file used as d
 SequentialExtendedLanguageTemplate_dsaProjectName=K3 DSA Project name
 SequentialExtendedLanguageTemplate_dsaProjectNameTooltip=K3 project containing aspects (for Domain Specific Actions for example). Optional, if not set, you'll be able to use a wizard to create it later.
 SequentialExtendedLanguageTemplate_title=Sequential Melange+K3 extended language project
-SequentialExtendedLanguageTemplate_desc=This template use a language extension mecanism (inheritance) in order to create a sequential language defined using a Melange language that is extended with K3 aspects in order to define a second language.
+SequentialExtendedLanguageTemplate_desc=This template use a language extension mechanism (inheritance) in order to create a sequential language defined using a Melange language that is extended with K3 aspects in order to define a second language.
 SequentialExtendedLanguageTemplate_wtitle=Sequential Melange+K3 extended language project
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>    
 
     <properties>
-		<tycho-version>1.7.0</tycho-version>
+		<tycho-version>2.2.0</tycho-version>
     	<xtend.version>2.24.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-execution-java.git</tycho.scmUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,12 @@
 
     <properties>
 		<tycho-version>1.7.0</tycho-version>
-    	<xtend.version>2.21.0</xtend.version>
+    	<xtend.version>2.24.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-execution-java.git</tycho.scmUrl>
 		<!-- <sonar.projectKey>gemoc:${project.groupId}:${project.artifactId}</sonar.projectKey>-->	
 		
-		<eclipse.release.p2.url>http://download.eclipse.org/releases/2020-03</eclipse.release.p2.url>
+		<eclipse.release.p2.url>http://download.eclipse.org/releases/2020-12</eclipse.release.p2.url>
 		<k3.p2.url>http://www.kermeta.org/k3/update_2018-09-05</k3.p2.url>
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-06-19</melange.p2.url>
 		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.4.1</elk.p2.url>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		
 		<eclipse.release.p2.url>http://download.eclipse.org/releases/2020-12</eclipse.release.p2.url>
 		<k3.p2.url>http://www.kermeta.org/k3/update_2018-09-05</k3.p2.url>
-		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-06-19</melange.p2.url>
+		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange.p2.url>
 		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.4.1</elk.p2.url>
 		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/48/dev/update</aspectJ.p2.url>
 <!--		<sirius.p2.url>https://download.eclipse.org/sirius/updates/releases/6.1.3/photon</sirius.p2.url>-->


### PR DESCRIPTION
## Description

This bump the base Eclipse to Eclipse 2020-12

This allows to solve start issue on MacOS

## Changes

It also bump other components:

- Xtend/Xtext to 2.24.0
- Tycho to 2.2.0
 
## Contribution to issues

Contribute to #  
Closes # 

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - PR https://github.com/eclipse/gemoc-studio/pull/219
 - PR https://github.com/eclipse/gemoc-studio-modeldebugging/pull/183
 - PR https://github.com/eclipse/gemoc-studio-execution-ale/pull/46
 - PR https://github.com/eclipse/gemoc-studio-moccml/pull/17
 - PR https://github.com/eclipse/gemoc-studio-execution-moccml/pull/49
