### PR TITLE
Add Sirius ELK support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<k3.p2.url>http://www.kermeta.org/k3/update_2018-09-05</k3.p2.url>
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange.p2.url>
 		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.7.1</elk.p2.url>
-		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/48/dev/update</aspectJ.p2.url>
+		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/410/dev/update</aspectJ.p2.url>
 <!--		<sirius.p2.url>https://download.eclipse.org/sirius/updates/releases/6.1.3/photon</sirius.p2.url>-->
 		
 		<maven.deploy.skip>false</maven.deploy.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<eclipse.release.p2.url>http://download.eclipse.org/releases/2020-12</eclipse.release.p2.url>
 		<k3.p2.url>http://www.kermeta.org/k3/update_2018-09-05</k3.p2.url>
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange.p2.url>
-		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.4.1</elk.p2.url>
+		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.7.1</elk.p2.url>
 		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/48/dev/update</aspectJ.p2.url>
 <!--		<sirius.p2.url>https://download.eclipse.org/sirius/updates/releases/6.1.3/photon</sirius.p2.url>-->
 		


### PR DESCRIPTION
## Description

This PR adds the ELK experimental support for Sirius. It provides better autolayout for Sirius diagram.

It also 
- cleans up some of the P2 repositories used while building
- remove some old repositories in the list of update sites presented in "Available update site" of the studio 

## Changes

ELK -> 0.7.1
Sirius ELK support
AJDT 4.10
remove nebula update site

 
## Contribution to issues

Closes https://github.com/eclipse/gemoc-studio/issues/221

## Companion Pull Requests


- https://github.com/eclipse/gemoc-studio/pull/222
- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/184
- https://github.com/eclipse/gemoc-studio-execution-moccml/pull/50
- https://github.com/eclipse/gemoc-studio-moccml/pull/18

 -  PR https://github.com/eclipse/gemoc-studio-modeldebugging/pull/184
