### PR TITLE
 Split commons eclipse pde to remove UI dependency

### DIFF
--- a/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/META-INF/MANIFEST.MF
+++ b/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.gemoc.dsl,
  org.eclipse.core.jobs,
  org.eclipse.jdt.core,
- org.eclipse.gemoc.xdsmlframework.commons.ui.k3
+ org.eclipse.gemoc.xdsmlframework.commons.ui.k3,
+ org.eclipse.gemoc.commons.eclipse.pde.ui;bundle-version="3.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/plugin.xml
+++ b/java_xdsml/plugins/org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui/plugin.xml
@@ -92,7 +92,7 @@
       </newWizardShortcut>
     </perspectiveExtension>
   </extension>
-  <extension point="org.eclipse.gemoc.commons.eclipse.pde.projectContent">
+  <extension point="org.eclipse.gemoc.commons.eclipse.pde.ui.projectContent">
     <wizard class="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.MelangeSequentialSingleLanguageNewWizard" id="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.projectContent.MelangeSequentialSingleLanguage" name="Simple GEMOC Melange Sequential project" targetPluginId="fr.inria.diverse.melange.ui">
       <description>
             This template creates a sequential language defined using a single Melange language and K3 aspects.
@@ -109,7 +109,7 @@
          </description>
     </wizard>
   </extension>
-  <extension point="org.eclipse.gemoc.commons.eclipse.pde.templates">
+  <extension point="org.eclipse.gemoc.commons.eclipse.pde.ui.templates">
     <template class="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.MelangeSequentialSingleLanguageTemplate" contributingId="fr.inria.diverse.melange.ui.templates.template1" id="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.template_simple_melange_sequential_language" name="Simple GEMOC Melange Sequential project"/>
     <template class="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.SequentialSingleLanguageTemplate" contributingId="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui" id="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.template_simple_sequential_language" name="Simple Sequential K3 language project"/>
     <template class="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.SequentialExtendedLanguageTemplate" contributingId="fr.inria.diverse.melange.ui.templates.template1" id="org.eclipse.gemoc.execution.sequential.javaxdsml.ide.ui.templates.template_sequential_extended_language" name="GEMOC Melange Extended Sequential project"/>


### PR DESCRIPTION
## Description

Adapt code to the split  of `org.eclipse.gemoc.commons.eclipse.pde` plugin (`org.eclipse.gemoc.commons.eclipse.pde` and `org.eclipse.gemoc.commons.eclipse.pde.ui`
 
## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - https://github.com/eclipse/gemoc-studio-commons/pull/1
 - https://github.com/eclipse/gemoc-studio/pull/276
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/224
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/70
