### PR TITLE
Manage step return values

### DIFF
--- a/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
+++ b/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import org.eclipse.core.runtime.CoreException;
@@ -245,7 +246,7 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 						}
 					};
 					fr.inria.diverse.k3.al.annotationprocessor.stepmanager.IStepManager stepManager = PlainK3ExecutionEngine.this;
-					stepManager.executeStep(entryPointMethodParameters.get(0), command, entryPointClass.getName(),
+					stepManager.executeStep(entryPointMethodParameters.get(0), initializeMethodParameters.toArray(), command, entryPointClass.getName(),
 							initializeMethod.getName());
 				} else {
 					callInitializeModel();
@@ -296,9 +297,9 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	@Override
 	public void executeStep(Object caller, Object[] parameters, StepCommand command, String className,
 			String methodName) {
-		executeOperation(caller, parameters, className, methodName, new Callable<Object>() {
+		executeOperation(caller, parameters, className, methodName, new Callable<Optional<Object>>() {
 			@Override
-			public Object call() throws Exception {
+			public Optional<Object> call() throws Exception {
 				command.execute();
 				return command.getResult();
 			}

--- a/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
+++ b/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Platform;
@@ -289,10 +290,17 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	 * java.lang.String)
 	 */
 	public void executeStep(Object caller, final StepCommand command, String className, String methodName) {
-		executeOperation(caller, className, methodName, new Runnable() {
+		executeStep(caller, new Object[0],command, className, methodName);
+	}
+	
+	@Override
+	public void executeStep(Object caller, Object[] parameters, StepCommand command, String className,
+			String methodName) {
+		executeOperation(caller, parameters, className, methodName, new Callable<Object>() {
 			@Override
-			public void run() {
+			public Object call() throws Exception {
 				command.execute();
+				return command.getResult();
 			}
 		});
 	}


### PR DESCRIPTION
## Description

Adapt the Java engine to the changes made in this PR: https://github.com/eclipse/gemoc-studio-modeldebugging/pull/226

Requires a change in K3 made in this other PR: https://github.com/diverse-project/k3/pull/87



## Changes

- Make `executeStep` return a value
- (Bonus)  Fix `initializeModel` which was not receiving its arguments correctly

 

## Companion Pull Requests

- Execution framework:  https://github.com/eclipse/gemoc-studio-modeldebugging/pull/226
- K3: https://github.com/diverse-project/k3/pull/87

