### PR TITLE
Bump to version of k3 including StepCommand return null fix

### DIFF
--- a/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
+++ b/java_engine/plugins/org.eclipse.gemoc.execution.sequential.javaengine/src/org/eclipse/gemoc/execution/sequential/javaengine/PlainK3ExecutionEngine.java
@@ -297,9 +297,9 @@ public class PlainK3ExecutionEngine extends AbstractCommandBasedSequentialExecut
 	@Override
 	public void executeStep(Object caller, Object[] parameters, StepCommand command, String className,
 			String methodName) {
-		executeOperation(caller, parameters, className, methodName, new Callable<Optional<Object>>() {
+		executeOperation(caller, parameters, className, methodName, new Callable<List<Object>>() {
 			@Override
-			public Optional<Object> call() throws Exception {
+			public List<Object> call() throws Exception {
 				command.execute();
 				return command.getResult();
 			}


### PR DESCRIPTION
## Description

Bump to the latest version of K3 that includes the support for all kind of StepCommand (ie. result being void, null or an object)

## Changes

Adapt the engine to the new return structure (ie. List)

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/284
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/229
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/59
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/74
